### PR TITLE
Fix typo from neutron_vlan_.. to network_vlan_..

### DIFF
--- a/templates/newton/ml2_conf_cisco_apic.ini
+++ b/templates/newton/ml2_conf_cisco_apic.ini
@@ -17,7 +17,7 @@ extension_drivers = {{ ml2_extension_drivers }}
 
 {% if neutron_vlan_ranges -%}
 [ml2_type_vlan]
-neutron_vlan_ranges = {{ neutron_vlan_ranges }}
+network_vlan_ranges = {{ neutron_vlan_ranges }}
 {% endif -%}
 
 [ovs]


### PR DESCRIPTION
Fix typo from neutron_vlan_ranges to network_vlan_ranges
