### PR TITLE
Aci/18.05 (#4)

### DIFF
--- a/templates/newton/ml2_conf_cisco_apic.ini
+++ b/templates/newton/ml2_conf_cisco_apic.ini
@@ -37,8 +37,13 @@ auth_plugin = {{ apic_aim_auth_plugin }}
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/v3
 username = {{ admin_user }}
 password = {{ admin_password }}
-user_domain_name = 'default'
-project_domain_name = 'default'
+{% if api_version == "3" -%}
+project_domain_name = {{ admin_domain_name }}
+user_domain_name = {{ admin_domain_name }}
+{% else -%}
+project_domain_name = default
+user_domain_name = default
+{% endif -%}
 project_name = {{ admin_tenant_name }}
 
 [group_policy]


### PR DESCRIPTION
Use identity-service rel data for service domain

* Remove hardcoded value on ml2_conf_cisco_apic.ini template and use project and user domain names from keystone:identity-service relation