### PR TITLE
Added new parameter 'aci-external-l3-domain' to name a pre-existing

### DIFF
--- a/templates/newton/ml2_conf_cisco_apic.ini
+++ b/templates/newton/ml2_conf_cisco_apic.ini
@@ -43,6 +43,9 @@ enable_security_group = True
 
 [ml2_apic_aim]
 enable_optimized_metadata = {{ aci_enable_optimized_metadata }}
+{% if aci_external_l3_domain -%}
+l3_domain_dn=uni/l3dom-{{ aci_external_l3_domain }}
+
 
 [apic_aim_auth]
 auth_plugin = {{ apic_aim_auth_plugin }}


### PR DESCRIPTION
l3-domain to automatcally attach to SVI/L3-Out created by neutron